### PR TITLE
Add SSH daemon to instances to troubleshoot what's wrong

### DIFF
--- a/cf/deploy.go
+++ b/cf/deploy.go
@@ -1,12 +1,15 @@
 package cf
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/pchico83/i2kit/k8"
 	"github.com/pchico83/i2kit/linuxkit"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 //NewDeploy deploys a k8 object
@@ -23,6 +26,13 @@ func NewDeploy(k8path string, awsConfig *aws.Config) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// TODO: for debugging purposes only, will be implemented when added a "verbose" flag
+			d, err := yaml.Marshal(&mobyTemplate)
+			if err != nil {
+				return fmt.Errorf("error marshalling: %v", err)
+			}
+			fmt.Printf("--- moby template:\n%s\n", string(d))
+			// END TODO
 			ami, err := linuxkit.Export(mobyTemplate, deployment.GetName())
 			if err != nil {
 				return err

--- a/linuxkit/aws_test.yml
+++ b/linuxkit/aws_test.yml
@@ -1,0 +1,37 @@
+kernel:
+  image: linuxkit/kernel:4.9.51
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:7804129bd06218b72c298139a25698a748d253c6
+  - linuxkit/runc:a1b564248a0d0b118c11e61db9f84ecf41dd2d2a
+  - linuxkit/containerd:417f83f7b8dc1fa36acf90effe44f99c7397480a
+  - linuxkit/ca-certificates:e44b0a66df5a102c0e220f0066b0d904710dcb10
+onboot:
+  - name: sysctl
+    image: linuxkit/sysctl:154913b72c6f1f33eb408609fca9963628e8c051
+  - name: rngd1
+    image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e
+    command: ["/sbin/rngd", "-1"]
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:f3f5413abb78fae9020e35bd4788fa93df4530b7
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: metadata
+    image: linuxkit/metadata:da3138079c168e0c5608d8f3853366c113ed91d2
+services:
+  - name: getty
+    image: linuxkit/getty:bf6872ce0a9f3ab519b3e502cc41ba3958bda2a6
+    env:
+     - INSECURE=true
+  - name: rngd
+    image: linuxkit/rngd:558e86a36242bb74353bc9287b715ddb8567357e
+  - name: sshd
+    image: linuxkit/sshd:d313eea3d9d7fbcbc927d06a6700325725db2a82
+files:
+  - path: root/.ssh/authorized_keys
+    source: ~/.ssh/dockercloud/staging/dcstaging_rsa.pub
+    mode: "0600"
+    optional: true
+trust:
+  org:
+    - linuxkit
+    - library

--- a/linuxkit/translate.go
+++ b/linuxkit/translate.go
@@ -9,7 +9,7 @@ import (
 
 //GetTemplate generates a linuxkit template from a k8 deployment object
 func GetTemplate(deployment *v1beta1.Deployment) (*moby.Moby, error) {
-	configBytes, err := ioutil.ReadFile("./linuxkit/aws.yml")
+	configBytes, err := ioutil.ReadFile("./linuxkit/aws_test.yml")
 	if err != nil {
 		return nil, err
 	}
@@ -17,12 +17,14 @@ func GetTemplate(deployment *v1beta1.Deployment) (*moby.Moby, error) {
 	if err != nil {
 		return nil, err
 	}
+	allCapabilities := &[]string{"all"}
 	for _, container := range deployment.Spec.Template.Spec.Containers {
 		mobyConfig.Services = append(
 			mobyConfig.Services,
 			moby.Image{
-				Name:  container.Name,
-				Image: container.Image,
+				Name:         container.Name,
+				Image:        container.Image,
+				Capabilities: allCapabilities,
 			},
 		)
 	}


### PR DESCRIPTION
So I managed to add SSH to the AMI generated. Looks like Nginx containers are not publishing their ports, needs deeper troubleshooting to see if there is any error with booting Nginx containers.

```
(ns: sshd) ip-10-78-44-188:~# runc list
ID             PID         STATUS      BUNDLE                            CREATED                          OWNER
000-sysctl     0           stopped     /containers/onboot/000-sysctl     2017-09-29T23:21:12.049307335Z   root
001-rngd1      0           stopped     /containers/onboot/001-rngd1      2017-09-29T23:21:12.081596597Z   root
002-dhcpcd     0           stopped     /containers/onboot/002-dhcpcd     2017-09-29T23:21:12.109239883Z   root
003-metadata   0           stopped     /containers/onboot/003-metadata   2017-09-29T23:21:12.173020271Z   root
(ns: sshd) ip-10-78-44-188:~# netstat -tanp
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      710/sshd
tcp        0    340 10.78.44.188:22         50.233.46.99:49196      ESTABLISHED 723/1
tcp        0      0 10.78.44.188:22         50.233.46.99:46725      ESTABLISHED 718/0
tcp        0      0 :::22                   :::*                    LISTEN      710/sshd
```